### PR TITLE
Fixes cli call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
 homepage = "https://github.com/AdunSG/yaml-extender"
 
 [project.scripts]
-yaml-extender = "reader.__main__:main"
+yaml-extender = "yaml_extender.cli:main"
+yaml_extender = "yaml_extender.cli:main"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION

`yaml-extender = "reader.__main__:main"` does not point anywhere

I also had some problems when I expected the tool to be called the same as the folder but it was a - instead of a _, so maybe squat on both.

I propose:
```toml
[project.scripts]
yaml-extender = "yaml_extender.cli:main"
yaml_extender = "yaml_extender.cli:main"
```
